### PR TITLE
/help 명령어 추가

### DIFF
--- a/src/main/java/com/shmoon/telegramreminderbot/bot/Commands.java
+++ b/src/main/java/com/shmoon/telegramreminderbot/bot/Commands.java
@@ -1,0 +1,8 @@
+package com.shmoon.telegramreminderbot.bot;
+
+public class Commands {
+
+    // help command
+    public static final String help = "/help";
+
+}

--- a/src/main/java/com/shmoon/telegramreminderbot/bot/Message.java
+++ b/src/main/java/com/shmoon/telegramreminderbot/bot/Message.java
@@ -1,0 +1,7 @@
+package com.shmoon.telegramreminderbot.bot;
+
+public class Message {
+
+    public static String helpMsg = "원하는 시간에 메시지를 전송합니다.";
+
+}

--- a/src/main/java/com/shmoon/telegramreminderbot/bot/ReminderBot.java
+++ b/src/main/java/com/shmoon/telegramreminderbot/bot/ReminderBot.java
@@ -1,5 +1,7 @@
 package com.shmoon.telegramreminderbot.bot;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
@@ -7,8 +9,11 @@ import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 
+
 @Component
 public class ReminderBot extends TelegramLongPollingBot {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @Value("${BOT_TOKEN_KEY}")
     private String botToken;
@@ -25,14 +30,47 @@ public class ReminderBot extends TelegramLongPollingBot {
 
     @Override
     public void onUpdateReceived(Update update) {
-        String chatId = String.valueOf(update.getMessage().getChatId());
-        String messageText = update.getMessage().getText();
-
         try {
-            execute(SendMessage.builder().chatId(chatId).text(messageText).build());
+            handleCommands(update);
         } catch (TelegramApiException e) {
-            e.printStackTrace();
+            logger.info("onUpdateReceived()", e);
         }
 
+    }
+
+    /**
+     * 명령어 핸들링 메서드
+     *
+     * @param update
+     * @throws TelegramApiException
+     */
+    private void handleCommands(Update update) throws TelegramApiException {
+        if (hasCommand(update)) {
+            String chatId = String.valueOf(update.getMessage().getChatId());
+            String messageText = update.getMessage().getText();
+
+            if (messageText.startsWith(Commands.help)) {
+                sendHelpMessage(chatId);
+            }
+        }
+    }
+
+    /**
+     * 명령어(command)인지 확인하는 메서드
+     *
+     * @param update
+     */
+    private boolean hasCommand(Update update) {
+        return update.getMessage().getEntities() != null && "bot_command".equals(update.getMessage().getEntities().get(0).getType());
+    }
+
+    /**
+     * /help 처리 메서드
+     *
+     * @param chatId
+     * @throws TelegramApiException
+     */
+    private void sendHelpMessage(String chatId) throws TelegramApiException {
+        execute(SendMessage.builder().chatId(chatId).text("도움말입니다.").build());
     }
 }

--- a/src/main/java/com/shmoon/telegramreminderbot/bot/ReminderBot.java
+++ b/src/main/java/com/shmoon/telegramreminderbot/bot/ReminderBot.java
@@ -45,13 +45,11 @@ public class ReminderBot extends TelegramLongPollingBot {
      * @throws TelegramApiException
      */
     private void handleCommands(Update update) throws TelegramApiException {
-        if (hasCommand(update)) {
-            String chatId = String.valueOf(update.getMessage().getChatId());
-            String messageText = update.getMessage().getText();
+        String chatId = String.valueOf(update.getMessage().getChatId());
+        String messageText = update.getMessage().getText();
 
-            if (messageText.startsWith(Commands.help)) {
-                sendHelpMessage(chatId);
-            }
+        if (messageText.startsWith(Commands.help)) {
+            sendHelpMessage(chatId);
         }
     }
 
@@ -59,7 +57,9 @@ public class ReminderBot extends TelegramLongPollingBot {
      * 명령어(command)인지 확인하는 메서드
      *
      * @param update
+     * @deprecated 명령어 검증에 있어 불필요하여 처리
      */
+    @Deprecated
     private boolean hasCommand(Update update) {
         return update.getMessage().getEntities() != null && "bot_command".equals(update.getMessage().getEntities().get(0).getType());
     }

--- a/src/main/java/com/shmoon/telegramreminderbot/bot/ReminderBot.java
+++ b/src/main/java/com/shmoon/telegramreminderbot/bot/ReminderBot.java
@@ -71,6 +71,6 @@ public class ReminderBot extends TelegramLongPollingBot {
      * @throws TelegramApiException
      */
     private void sendHelpMessage(String chatId) throws TelegramApiException {
-        execute(SendMessage.builder().chatId(chatId).text("도움말입니다.").build());
+        execute(SendMessage.builder().chatId(chatId).text(Message.helpMsg).build());
     }
 }

--- a/src/test/java/com/shmoon/telegramreminderbot/bot/ReminderBotTest.java
+++ b/src/test/java/com/shmoon/telegramreminderbot/bot/ReminderBotTest.java
@@ -3,6 +3,13 @@ package com.shmoon.telegramreminderbot.bot;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.MessageEntity;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -16,6 +23,42 @@ class ReminderBotTest {
     @Test
     void 기본_설정_테스트() {
         assertThat(reminderBot).isNotNull();
+    }
+
+    @Test
+    void 명령어_확인_테스트() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // case
+        Method method = ReminderBot.class.getDeclaredMethod("hasCommand", Update.class);
+        method.setAccessible(true);
+        Update update = new Update();
+        update.setMessage(new Message());
+
+        ArrayList<MessageEntity> messageEntities = new ArrayList<>();
+        MessageEntity messageEntity = new MessageEntity();
+        messageEntity.setType("bot_command");
+        messageEntities.add(messageEntity);
+        update.getMessage().setEntities(messageEntities);
+
+        // when
+        boolean isCommand = (boolean) method.invoke(reminderBot, update);
+
+        // then
+        assertTrue(isCommand);
+    }
+
+    @Test
+    void 일반메시지_확인_테스트() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        // case
+        Method method = ReminderBot.class.getDeclaredMethod("hasCommand", Update.class);
+        method.setAccessible(true);
+        Update update = new Update();
+        update.setMessage(new Message());
+
+        // when
+        boolean isCommand = (boolean) method.invoke(reminderBot, update);
+
+        // then
+        assertFalse(isCommand);
     }
 
 


### PR DESCRIPTION
- [x]  /help 명령어 추가 및 기본 세팅
- [x] hasCommand() 사용 로직 삭제 - 실제로 검증하는 데 있어 불필요
- [x] 정적 메시지 별도 관리하도록 수정 

테스트 코드 작성 시 private 메서드 이슈 - https://www.crocus.co.kr/1665
